### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 python-dotenv
 openai
 langchain
-llama-index==0.8.2
+llama-index
 pypdf
 PyCryptodome
 gradio


### PR DESCRIPTION
Fix error

❯ python report.py
/Volumes/FastSSD2/LLM/LamaIndex/.venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:269: UserWarning: Valid config keys have changed in V2:
* 'allow_population_by_field_name' has been renamed to 'populate_by_name' warnings.warn(message, UserWarning) Traceback (most recent call last):
  File "/Volumes/FastSSD2/LLM/LamaIndex/llamaindex-metadata-financial-reports/report.py", line 1, in <module> from llama_index import SimpleDirectoryReader, VectorStoreIndex, load_index_from_storage File "/Volumes/FastSSD2/LLM/LamaIndex/.venv/lib/python3.11/site-packages/llama_index/__init__.py", line 12, in <module> from llama_index.data_structs.struct_type import IndexStructType File "/Volumes/FastSSD2/LLM/LamaIndex/.venv/lib/python3.11/site-packages/llama_index/data_structs/__init__.py", line 3, in <module> from llama_index.data_structs.data_structs import ( File "/Volumes/FastSSD2/LLM/LamaIndex/.venv/lib/python3.11/site-packages/llama_index/data_structs/data_structs.py", line 14, in <module> from llama_index.schema import BaseNode, TextNode File "/Volumes/FastSSD2/LLM/LamaIndex/.venv/lib/python3.11/site-packages/llama_index/schema.py", line 215, in <module> class TextNode(BaseNode): File "/Volumes/FastSSD2/LLM/LamaIndex/.venv/lib/python3.11/site-packages/llama_index/schema.py", line 242, in TextNode @root_validator ^^^^^^^^^^^^^^ File "/Volumes/FastSSD2/LLM/LamaIndex/.venv/lib/python3.11/site-packages/pydantic/deprecated/class_validators.py", line 222, in root_validator return root_validator()(*__args)  # type: ignore ^^^^^^^^^^^^^^^^ File "/Volumes/FastSSD2/LLM/LamaIndex/.venv/lib/python3.11/site-packages/pydantic/deprecated/class_validators.py", line 228, in root_validator raise PydanticUserError( pydantic.errors.PydanticUserError: If you use `@root_validator` with pre=False (the default) you MUST specify `skip_on_failure=True`. Note that `@root_validator` is deprecated and should be replaced with `@model_validator`.

For further information visit https://errors.pydantic.dev/2.3/u/root-validator-pre-skip